### PR TITLE
Python3 fixes

### DIFF
--- a/gq-gmc-control.py
+++ b/gq-gmc-control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 #  This program is free software: you can redistribute it and/or modify

--- a/gq_gmc.py
+++ b/gq_gmc.py
@@ -425,7 +425,7 @@ def parse_data_file(in_file=DEFAULT_BIN_FILE, out_file=DEFAULT_CSV_FILE,
                 continue
             else:
                 # possible command turns out to be a regular value
-                f_out.write(print_data(f_out, data_type, chr(0x55), size=1,
+                f_out.write(print_data(f_out, data_type, b"7", size=1,
                                        cpm_to_usievert=cpm_to_usievert) + "\n")
                 marker = 0
         else:


### PR DESCRIPTION
Convert the code to run as Python3, since Python2 has been unsupported for over 4 years.

Most of the fixes involve `serial.Serial.read` and `struct.pack` now returning a `bytes` object instead of a string. I've tested a few of the commands on my GMC-500+ and in a Python3 interpreter with the `-b` flag which additionally warns about comparing `str` to `bytes` (an easy pitfall otherwise).

I also went ahead and simplified many cases of e.g.:
```python
if s == '' and len(s) < 7:
```
to just:
```python
if len(s) < 7:
```

I have not tested all the available commands, but I can confirm that reading data off the device and into a CSV file is working. I do notice some artifacts at the tail end of the flash memory dump, there's a long run of CPS=255 which I assume is from a parsing error. I don't know if this behaviour is present before these Python3 fixes.